### PR TITLE
Add OSX conda requirements file

### DIFF
--- a/lcp_OSX.yml
+++ b/lcp_OSX.yml
@@ -1,0 +1,9 @@
+name: LCP
+dependencies:
+- python=2.7
+- numpy=1.8.1
+- scipy=0.13.3
+- matplotlib=1.3.1
+- scikit-learn=0.14.1
+- ipython=2.3.0
+- pyzmq=2.2.0


### PR DESCRIPTION
Scipy on Linux depends on libgfortran, but scipy on Mac does not. To address this issue a separate requirements file for OSX is added.